### PR TITLE
indentation fix

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -160,7 +160,7 @@ class BasePlugin:
 			poller = MiFloraPoller(str(mac), BluepyBackend)
 			Domoticz.Debug("Firmware: {}".format(poller.firmware_version()))
 			val_bat  = int("{}".format(poller.parameter_value(MI_BATTERY)))
-                	nValue = 0
+			nValue = 0
 		except:
 			Domoticz.Log("poller error")
 


### PR DESCRIPTION
I don't have the error `Error Line '                      nValue = 0 ` with this fix. 
It starts fine:

```
2018-12-17 19:27:55.726  Status: (Pots_Fleurs) Started.
2018-12-17 19:27:56.308  Status: (Pots_Fleurs) Entering work loop.
2018-12-17 19:27:56.308  Status: (Pots_Fleurs) Initialized version 1.0.0, author 'blauwebuis'
2018-12-17 19:27:56.311  (Pots_Fleurs) Automatic mode is selected
2018-12-17 19:27:56.311  (Pots_Fleurs) Scanning for Mi Flower Mate sensors
2018-12-17 19:27:56.332  (Pots_Fleurs) Already known devices:['C4:7C:8D:65:AB:CD', 'C4:7C:8D:65:AB:CD']
2018-12-17 19:27:59.488  (Pots_Fleurs) Number of devices found via bluetooth scan = 2
2018-12-17 19:27:59.491  (Pots_Fleurs) Created device: Pots_Fleurs - #0 Moisture
2018-12-17 19:27:59.493  (Pots_Fleurs) Created device: Pots_Fleurs - #0 Temperature
2018-12-17 19:27:59.496  (Pots_Fleurs) Created device: Pots_Fleurs - #0 Light
2018-12-17 19:27:59.498  (Pots_Fleurs) Created device: Pots_Fleurs - #0 Conductivity
2018-12-17 19:27:59.500  (Pots_Fleurs) Created device: Pots_Fleurs - #1 Moisture
2018-12-17 19:27:59.503  (Pots_Fleurs) Created device: Pots_Fleurs - #1 Temperature
2018-12-17 19:27:59.505  (Pots_Fleurs) Created device: Pots_Fleurs - #1 Light
2018-12-17 19:27:59.508  (Pots_Fleurs) Created device: Pots_Fleurs - #1 Conductivity
```

